### PR TITLE
Add leather knowledge bot for e-commerce platform responses

### DIFF
--- a/autogpt/commands/leather_info.py
+++ b/autogpt/commands/leather_info.py
@@ -1,0 +1,20 @@
+"""Leather knowledge commands for the leather bot."""
+from __future__ import annotations
+
+from autogpt.commands.command import command
+
+LEATHER_KNOWLEDGE = {
+    "cowhide": "牛皮耐磨，常用于皮鞋和皮包。",
+    "sheepskin": "羊皮柔软，适合制作服装。",
+    "care": "皮革应避免潮湿，并定期使用保养油。",
+}
+
+
+@command("get_leather_info", "Get leather info", '"topic": "<topic>"')
+def get_leather_info(topic: str) -> str:
+    """Return knowledge about a specific leather topic.
+
+    Args:
+        topic: Topic to search in the leather knowledge base.
+    """
+    return LEATHER_KNOWLEDGE.get(topic.lower(), "暂无该皮革主题的相关知识。")

--- a/autogpt/leather_bot.py
+++ b/autogpt/leather_bot.py
@@ -1,0 +1,34 @@
+"""Leather knowledge bot that replies to platform customer service bots."""
+from __future__ import annotations
+
+from autogpt.commands.leather_info import get_leather_info
+
+
+class LeatherKnowledgeBot:
+    """Simple bot offering leather related knowledge with platform specific replies."""
+
+    PLATFORM_TEMPLATES = {
+        "taobao": "淘宝客服您好！{info}",
+        "douyin": "抖音客服您好！{info}",
+        "xiaohongshu": "小红书客服您好！{info}",
+    }
+
+    PRODUCT_SUGGESTIONS = {
+        "cowhide": "经典牛皮包，适合日常通勤",
+        "sheepskin": "舒适羊皮夹克，柔软贴身",
+        "care": "皮革护理油，延长使用寿命",
+    }
+
+    def respond(self, platform: str, topic: str) -> str:
+        """Return leather knowledge and product suggestions for a platform.
+
+        Args:
+            platform: Name of the platform requesting information.
+            topic: Leather topic to respond about.
+        """
+        info = get_leather_info(topic)
+        product = self.PRODUCT_SUGGESTIONS.get(topic.lower())
+        if product:
+            info = f"{info} 推荐商品：{product}"
+        template = self.PLATFORM_TEMPLATES.get(platform.lower(), "{info}")
+        return template.format(info=info)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import os
 import pytest
 from pytest_mock import MockerFixture
 
@@ -7,7 +8,12 @@ from autogpt.config import Config
 from autogpt.llm import ApiManager
 from autogpt.workspace import Workspace
 
-pytest_plugins = ["tests.integration.agent_factory"]
+# Allow tests to opt-out of heavy integration fixtures to avoid importing
+# optional dependencies such as `spacy` when running lightweight unit tests.
+if os.getenv("SKIP_INTEGRATION_PLUGINS") == "1":
+    pytest_plugins: list[str] = []
+else:
+    pytest_plugins = ["tests.integration.agent_factory"]
 
 
 @pytest.fixture()

--- a/tests/unit/test_leather_bot.py
+++ b/tests/unit/test_leather_bot.py
@@ -1,0 +1,16 @@
+"""Tests for LeatherKnowledgeBot."""
+from autogpt.leather_bot import LeatherKnowledgeBot
+
+
+def test_leather_bot_platform_response():
+    bot = LeatherKnowledgeBot()
+    response = bot.respond("taobao", "cowhide")
+    assert "淘宝客服" in response
+    assert "牛皮耐磨" in response
+    assert "推荐商品：经典牛皮包" in response
+
+
+def test_leather_bot_unknown_platform():
+    bot = LeatherKnowledgeBot()
+    response = bot.respond("unknown", "care")
+    assert response == "皮革应避免潮湿，并定期使用保养油。 推荐商品：皮革护理油，延长使用寿命"


### PR DESCRIPTION
## Summary
- add command to retrieve leather information
- implement LeatherKnowledgeBot with platform-specific reply templates and product suggestions
- allow tests to skip heavy integration fixtures
- include unit tests for platform responses and recommendations

## Testing
- `SKIP_INTEGRATION_PLUGINS=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_leather_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6279583048329a336af6c46bcf28a